### PR TITLE
Data validation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ancillary files `.ilocus.mrnas.txt` and `.protein2ilocus.txt` are not `.tsv` files with headers.
 - Extensive documentation updates.
 - Switched from nose to py.test as the testing framework.
-- Updated checksums for many NCBI annotations to compensate for changes in `##species` pragmas, transcript metadata, and annotations for mobile elements, antisense transcripts, origins of replication, and various other features.
+- Updated checksums for many NCBI annotations to compensate for:
+    - changes in `##species` pragmas
+    - transcript evidence descriptions and other metadata
+    - feature types for annotated mobile elements, antisense transcripts, origins of replication, and various other features
+    - an update to the *C. elegans* annotation (< 1% gene models affected)
+    - an update to the *D. rerio* annotation (≈ 3% CDSs, ≈ 10% gene models affected)
 
 ### Removed
 - Deprecated `genhub-fix-trna.py` script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ancillary files `.ilocus.mrnas.txt` and `.protein2ilocus.txt` are not `.tsv` files with headers.
 - Extensive documentation updates.
 - Switched from nose to py.test as the testing framework.
+- Updated checksums for many NCBI annotations to compensate for changes in `##species` pragmas, transcript metadata, and annotations for mobile elements, antisense transcripts, origins of replication, and various other features.
 
 ### Removed
 - Deprecated `genhub-fix-trna.py` script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - transcript evidence descriptions and other metadata
     - feature types for annotated mobile elements, antisense transcripts, origins of replication, and various other features
     - an update to the *C. elegans* annotation (< 1% gene models affected)
-    - an update to the *D. rerio* annotation (≈ 3% CDSs, ≈ 10% gene models affected)
+    - an update to the *D. rerio* annotation (≈ 3% CDS exons, ≈ 10% all exons affected)
+    - an update to the *M. musculus* annotation (1% CDS exons, 5% of all exons affected)
 
 ### Removed
 - Deprecated `genhub-fix-trna.py` script.

--- a/genhub/genomes/Aaeg.yml
+++ b/genhub/genomes/Aaeg.yml
@@ -7,6 +7,6 @@ Aaeg:
     build: AaegL2
     checksums:
         gdna: 27e8f1c53349b0aa4c031df0df6b196e82e48ac2
-        gff3: 197063a3bf5520a817a9174c31a154518feb4fc8
+        gff3: 73efa24d07a6ae1ce94b4a138aff3e604c99adad
         prot: b39db28b217e2bba655788c524db711b82f7cdf7
     description: AaegL2 from TIGR

--- a/genhub/genomes/Acep.yml
+++ b/genhub/genomes/Acep.yml
@@ -8,6 +8,6 @@ Acep:
     build: Attacep1.0
     checksums:
         gdna: 473902070fe165f0f8a8e5a64edf2509b11af72b
-        gff3: bac3bf9cff45ed37da89a2f407fb0cfc954ae081
+        gff3: 49f73b8aa9cae062a9c0626df03a149ba7fc8261
         prot: 0f8685aff6f2b6b7fdb961182c743330bd5bbec4
     description: AttaCep1.0 from WashU GSC

--- a/genhub/genomes/Ador.yml
+++ b/genhub/genomes/Ador.yml
@@ -10,6 +10,6 @@ Ador:
     build: Apis_dorsata_1.3
     checksums:
         gdna: 4eac29771d018d9a1f7f67bccbdeb7dace37f74c
-        gff3: 4b8306d5832c86a9d63fe617265b77321e7a2ed1
+        gff3: f11b95257b4331af1c735785e46267daec688780
         prot: a53a2d9d517c77605e01e54406c875129654277b
     description: Apis_dorsata_1.3 from CSHL

--- a/genhub/genomes/Aech.yml
+++ b/genhub/genomes/Aech.yml
@@ -8,6 +8,6 @@ Aech:
     build: Aech_3.9
     checksums:
         gdna: 7085caf56df9f094aed4cfff0d9ef34509db9a3d
-        gff3: 769e2a3c47f7133ccdea4716ae3d0cb1b51d83cd
+        gff3: e601598dc6d82c1cba9ff498c92a53359f58aff2
         prot: 4ce2daff273a6dd6c602a23d2b518156d860477c
     description: Aech_3.9 from BGI-Shenzhen

--- a/genhub/genomes/Aflo.yml
+++ b/genhub/genomes/Aflo.yml
@@ -26,6 +26,6 @@ Aflo:
         - 'GeneID:100868109'
     checksums:
         gdna: cadd39c59a1d5b10c67c78d8c2c3e38a8aa091ae
-        gff3: 25b41c7fb8ec641edac856ab8ad11486d493bf64
+        gff3: 22fe8e1bae43f8c33b57ba4841d112fe11d74c61
         prot: 05b76c748e7a8002894ee48825f3739a4b1a5a1a
     description: Aflo_1.0 from HGSC@Baylor

--- a/genhub/genomes/Agam.yml
+++ b/genhub/genomes/Agam.yml
@@ -13,6 +13,6 @@ Agam:
         - NC_002084.1
     checksums:
         gdna: 1618adb863cda2c00c45d642c609b53f5e86aa02
-        gff3: 182800f4787ddcfde670ccb2b0262544889c6cdf
+        gff3: 36786ec4cd934a5a76bb91092bb3d154b3d31fc1
         prot: 9586cba9beda13caf8a0f2f54272a61862f98ba9
     description: AgamP3 from the Anopheles sequencing consortium

--- a/genhub/genomes/Amel.yml
+++ b/genhub/genomes/Amel.yml
@@ -14,6 +14,6 @@ Amel:
         - NC_001566.1
     checksums:
         gdna: d301a875b9cd8320eca1c31cb9ebfd4f79edf7ed
-        gff3: d858a1db0fe765955956ef71af832033adf30d35
+        gff3: 6517864c309057a9bd497da38d9dfb0f15284efc
         prot: e485036bfe47c69dbeb13e32537cacbb4574c787
     description: Amel_4.5 from HGSC@Baylor

--- a/genhub/genomes/Atha.yml
+++ b/genhub/genomes/Atha.yml
@@ -19,4 +19,4 @@ Atha:
     checksums:
         gdna: 3d8278d485c33a7920c1cfd09545bbc179fc8d00
         gff3: 1ee68030bfb644db9a3e15b58199067c6fde7336
-        prot: 55cefaf86350639f77c520887e37c1a6a4e87451
+        prot: 71d3d4528d963ae1842515f892b312784484d94b

--- a/genhub/genomes/Atha.yml
+++ b/genhub/genomes/Atha.yml
@@ -18,5 +18,5 @@ Atha:
     description: TAIR10 from TAIR
     checksums:
         gdna: 3d8278d485c33a7920c1cfd09545bbc179fc8d00
-        gff3: 3a9350d28d87e2dce07f20b0602afbd19f79ec26
+        gff3: 1ee68030bfb644db9a3e15b58199067c6fde7336
         prot: 55cefaf86350639f77c520887e37c1a6a4e87451

--- a/genhub/genomes/Bdis.yml
+++ b/genhub/genomes/Bdis.yml
@@ -12,6 +12,6 @@ Bdis:
         - NC_011032.1
     checksums:
         gdna: a7140dde7f1bf3017a7dc2a47d37d4e56496765a
-        gff3: 11c352f2483784a7acb1c3c200601969a444439f
-        prot: c70e1b2df2780da33aea71fa2b61908a795c4c3e
+        gff3: 34ebba883133a3f91fa657c393a603ac59a9dc13
+        prot: c3c8412f23da39064b4afe85b34384f11a4c4ba0
     description: Brachypodium_distachyon_v2.0 from JGI

--- a/genhub/genomes/Bimp.yml
+++ b/genhub/genomes/Bimp.yml
@@ -10,6 +10,6 @@ Bimp:
     build: BIMP_2.0
     checksums:
         gdna: 311bb5a6f3caf75c48b7c83ead6fdcb7b6bbb4a2
-        gff3: 50b2b0dcfcf9e5840417ed2ae3f0f7f9e4e7636a
+        gff3: a7106864ca2eb38b6b5dca800c5c98400df9b216
         prot: b694e018b0c8a5194746e6ac52eca34df0385154
     description: BIMP_2.0 from University of Illinois

--- a/genhub/genomes/Bole.yml
+++ b/genhub/genomes/Bole.yml
@@ -12,6 +12,6 @@ Bole:
         - NC_016118.1
     checksums:
         gdna: 8e85a73183ec9004b9d5cfca0f6a39580f3b5e4a
-        gff3: 8b33bcf49ef890a59d4ca391b99c1d9ac6597347
+        gff3: 86342ed634ce2b565f852de61f8b5e442a357914
         prot: ead59da992814a9b5828a501f96211278984c689
     description: Build BOL from CanSeq

--- a/genhub/genomes/Btau.yml
+++ b/genhub/genomes/Btau.yml
@@ -11,6 +11,6 @@ Btau:
         - NC_006853.1
     checksums:
         gdna: 4379ee8c138ae91a8dd1126a9689dc763a419373
-        gff3: f784a357f32cc818e71d93971b430ea2586204e9
-        prot: 7f2bec8329261e418ed7810f1c883ae4ad1fbcc3
+        gff3: 25ecbcbb7010bb4ac9e27439365b36dc5797ea64
+        prot: 7ebbb070214210f45354a904572941a56050004c
     description: Bos_taurus_UMD_3.1.1 from the University of Maryland

--- a/genhub/genomes/Btau.yml
+++ b/genhub/genomes/Btau.yml
@@ -11,6 +11,6 @@ Btau:
         - NC_006853.1
     checksums:
         gdna: 4379ee8c138ae91a8dd1126a9689dc763a419373
-        gff3: 25ecbcbb7010bb4ac9e27439365b36dc5797ea64
+        gff3: cde81e8f5b635916c7316d4d9805a067fa4d6cf9
         prot: 7ebbb070214210f45354a904572941a56050004c
     description: Bos_taurus_UMD_3.1.1 from the University of Maryland

--- a/genhub/genomes/Bter.yml
+++ b/genhub/genomes/Bter.yml
@@ -21,6 +21,6 @@ Bter:
         - 'GeneID:100648960'
     checksums:
         gdna: 43c26f7df40173119062341929c0fa07de303821
-        gff3: bb2995c05587546dd68e933f638c5ac11758f08b
+        gff3: 61900ffb404f460d0681f2b6004df44408651997
         prot: 2b33ea870cdf72d2a744ce8a19bc6959ef454cf3
     description: Bter_1.0 from HGSC@Baylor

--- a/genhub/genomes/Cari.yml
+++ b/genhub/genomes/Cari.yml
@@ -12,6 +12,6 @@ Cari:
         - NC_011163.1
     checksums:
         gdna: f014c6e79ada4bc5de256a4415395d3a89f0cb58
-        gff3: 99c9234071f6cda431c0594f70c83a2c49086941
-        prot: 0790bafded1a250f999eb0d835d5d9ea36224fc6
+        gff3: 7cc980985b24102b5bc24afd4970cdbab39305f3
+        prot: 73930e03d405623557902f50d010182e2622e916
     description: Build ASM33114v1 from BGI

--- a/genhub/genomes/Cbir.yml
+++ b/genhub/genomes/Cbir.yml
@@ -8,7 +8,6 @@ Cbir:
     build: CerBir1.0
     checksums:
         gdna: c175569906b4e7d92c011e11ec4300cf7db29dda
-        gff3: c4e093ba252f125a6f900ac3044fab08cf68bd51
+        gff3: a47c65f9a6fbbcabc1c8e3aa8b98a8b6498c056b
         prot: b70ac88d8599118a4fe9693d405ffa4979ca3f3f
     description: CerBir1.0 from BGI-Shenzhen
-

--- a/genhub/genomes/Cele.yml
+++ b/genhub/genomes/Cele.yml
@@ -13,6 +13,6 @@ Cele:
     fixseqreg: true
     checksums:
         gdna: 25f7bca0e887f5e1793211d43e32b7abbfa1bc6b
-        gff3: 142b22b644e8c2f61de4ae0d8813b088f1b3aea2
+        gff3: 22f6df5a2ab2f73bd13d446c4b27bd2908bf5fcc
         prot: 55848753f9c8bd4eee3c35716f598973eba99802
     description: WBcel235 from the C. elegans sequencing consortium

--- a/genhub/genomes/Cflo.yml
+++ b/genhub/genomes/Cflo.yml
@@ -8,6 +8,6 @@ Cflo:
     build: CamFlo_1.0
     checksums:
         gdna: 389d8de5a0a8a43b91ce51d5d9c22cbf5e7b779f
-        gff3: 6dd3f9bb894cc4b78c937ef88d369e2003a2f108
+        gff3: 309f0ad67ce997550ec8fe4a25a27dfdac1d6796
         prot: dd7443dcbbe7698755a5ddf021f7888301429abe
     description: CamFlo_1.0 from BGI-Shenzhen

--- a/genhub/genomes/Crei.yml
+++ b/genhub/genomes/Crei.yml
@@ -14,6 +14,6 @@ Crei:
         - NC_005353.1
     checksums:
         gdna: c7e8332282880cbfadc06c70ff1fa2dc6246d724
-        gff3: 6c49e9df6d13bfdba72f892c2c242c213e3a1d4f
+        gff3: 8b1cb200a53cd3fdc032c478268a7f2c96411a81
         prot: 98b4c542d75c64a94b4b98bcc1a3a38239b34578
     description: v3.0 from JGI

--- a/genhub/genomes/Csub.yml
+++ b/genhub/genomes/Csub.yml
@@ -7,6 +7,6 @@ Csub:
     build: Coccomyxa_subellipsoidae_v2.0
     checksums:
         gdna: 65048a13686b7b1a8b29e95d08160c6c33ef0c23
-        gff3: cc5a9cba3857b34849d5fc9e79f481f79015c236
+        gff3: 5e3b253ea7bcb9d1c948b012351484939a6e7abc
         prot: 450e2586d37ad0b8a7bf2cadf455c6c47082e9e8
     description: v2.0 from JGI

--- a/genhub/genomes/Dmel.yml
+++ b/genhub/genomes/Dmel.yml
@@ -13,6 +13,6 @@ Dmel:
         - NC_024511.2
     checksums:
         gdna: e4176036c90a917372821bbf3498f6d232e69690
-        gff3: 663c24c44972d553e60493402a7746f1fc43d7dd
+        gff3: 449344e7088d131c9013f6736748a31020dbfa47
         prot: f25381f7f441ddf02eb45cd2b38b003cf4ce9dfb
     description: Release 6 (plus ISO1 MT) from the FlyBase Consortium

--- a/genhub/genomes/Dmel.yml
+++ b/genhub/genomes/Dmel.yml
@@ -13,6 +13,6 @@ Dmel:
         - NC_024511.2
     checksums:
         gdna: e4176036c90a917372821bbf3498f6d232e69690
-        gff3: 449344e7088d131c9013f6736748a31020dbfa47
+        gff3: 43588f274f8965f9a1ac069c7948a14ab7292de9
         prot: f25381f7f441ddf02eb45cd2b38b003cf4ce9dfb
     description: Release 6 (plus ISO1 MT) from the FlyBase Consortium

--- a/genhub/genomes/Dqua.yml
+++ b/genhub/genomes/Dqua.yml
@@ -7,6 +7,6 @@ Dqua:
     build: ASM131382v1
     checksums:
         gdna: b92587077c74c535a1444fe1bba580807a4e47c7
-        gff3: 3cfc24264ccd6a7e50d37bc45c89bebd7de30ce7
+        gff3: 0c92423168834cf8e3403e5eb20a38667d6eab20
         prot: 19e66497c1a6a0a2f998d98432573848bbb386d1
     description: ASM131382v1 from the CRG

--- a/genhub/genomes/Drer.yml
+++ b/genhub/genomes/Drer.yml
@@ -12,6 +12,6 @@ Drer:
         - NC_002333.2
     checksums:
         gdna: a94a614ac7592fad2f274c24fc67d7b9ccd5f5b3
-        gff3: 86cfdb01209513bbac6a3a65672cb422ceab0eb1
-        prot: 51ecdf02b022799598ba4770fbb4def25c535bb2
+        gff3: 72eb6a8e69ac772f9ac9f084043a9a6c05e23786
+        prot: ce0857d220b62d68badbe2bdb8823cd83bcf2025
     description: GRCz10 from the Genome Reference Consortium

--- a/genhub/genomes/Gmax.yml
+++ b/genhub/genomes/Gmax.yml
@@ -14,6 +14,6 @@ Gmax:
         - NC_020455.1
     checksums:
         gdna: f893514cf22b4e865ab8e25969d2fe2a8e20b264
-        gff3: 71c78a9a3b48eba82623a0cfc304a97032366fd2
-        prot: 557ba82358bb3f11b6f30bc102c4bcd1141462d1
+        gff3: 8b3073a10d68df5b6b4b8abc5471e4e7e403c935
+        prot: 4ee64a991020430f9be418382a0045ae7f8c96ca
     description: Glycine_max_v2.0 from JGI

--- a/genhub/genomes/Gmax.yml
+++ b/genhub/genomes/Gmax.yml
@@ -14,6 +14,6 @@ Gmax:
         - NC_020455.1
     checksums:
         gdna: f893514cf22b4e865ab8e25969d2fe2a8e20b264
-        gff3: 8b3073a10d68df5b6b4b8abc5471e4e7e403c935
+        gff3: 1efea81522b38a8adfd7e6d1365476837d90eca5
         prot: 4ee64a991020430f9be418382a0045ae7f8c96ca
     description: Glycine_max_v2.0 from JGI

--- a/genhub/genomes/Grai.yml
+++ b/genhub/genomes/Grai.yml
@@ -10,4 +10,8 @@ Grai:
         - NC_016668.1
     seqfilter:
         - NC_016668.1
+    checksums:
+        gdna: 46c9209e9fc82d4b4fc7f42e76f422f438591c41
+        gff3: 35f8c180a05b32f2b1fa96f4cf5e1526344b72a8
+        prot: fb1f8c2d67b2633b079ab8dee50d3d3c94cf9c10
     description: 2.0 from JGI

--- a/genhub/genomes/Hsal.yml
+++ b/genhub/genomes/Hsal.yml
@@ -8,6 +8,6 @@ Hsal:
     build: HarSal_1.0
     checksums:
         gdna: 73b508cf0a0f7905b2fc46d0afef451b8802f45d
-        gff3: 53458cf561bf8c0f12eb201c846845811bb29634
+        gff3: 77078441c4ef0554e232403428af377c7f27a7c0
         prot: 93261734dd34c9e3858492fcc04c67e6533a24af
     description: HarSal_1.0 from BGI-Shenzhen

--- a/genhub/genomes/Lhum.yml
+++ b/genhub/genomes/Lhum.yml
@@ -8,7 +8,6 @@ Lhum:
     build: Lhum_UMD_V04
     checksums:
         gdna: dc44f2c114cfb0d626084fdae054522f2d5620d8
-        gff3: b30119bb869e0a04d23b1496b81254cd66d9673b
+        gff3: 32525afb94d83dfecee6462846d593210dbb38da
         prot: bcc4a7e4c64a657d3ea2a348bb74650389aff6f7
     description: Lhum_UMD_V04 from the Ant Genomics Consortium
-

--- a/genhub/genomes/Mcom.yml
+++ b/genhub/genomes/Mcom.yml
@@ -13,6 +13,6 @@ Mcom:
         - NC_012643.1
     checksums:
         gdna: 3b8e3a973443c2e592843a2581630c0957235e29
-        gff3: 325fa07138857180ad26c63704a32255fa223b91
+        gff3: 74c6254f6be03e11edebc52dc43090b290afd466
         prot: 45dd93a569dd8fffbb6d8ad8c4eeeee69d10b710
     description: ASM9098v2 from the Micromonas Genome Consortium

--- a/genhub/genomes/Mmus.yml
+++ b/genhub/genomes/Mmus.yml
@@ -14,7 +14,7 @@ Mmus:
         - NW_
         - NT_
     checksums:
-        gdna: 2357e4802d5185449936f3971e41c73fa46c2fde
-        gff3: 0d4608d127d3402eecf7c65de640762cc795a749
-        prot: 053976f8f370fad57a371ee8424066ae91668af9
+        gdna: c2598bc76966740ef4053a285e795185fad56b89
+        gff3: 24fbd11d7adc62eba498308933b4de36a08b61e6
+        prot: cd834f9c48ec95f9c3401e441ccd883548d2ea02
     description: GRCm38.p4 from the Genome Reference Consortium

--- a/genhub/genomes/Mmus.yml
+++ b/genhub/genomes/Mmus.yml
@@ -15,6 +15,6 @@ Mmus:
         - NT_
     checksums:
         gdna: c2598bc76966740ef4053a285e795185fad56b89
-        gff3: 24fbd11d7adc62eba498308933b4de36a08b61e6
+        gff3: c864f885e6f127cfd0be82f69badd9a42d376eaf
         prot: cd834f9c48ec95f9c3401e441ccd883548d2ea02
     description: GRCm38.p4 from the Genome Reference Consortium

--- a/genhub/genomes/Mrot.yml
+++ b/genhub/genomes/Mrot.yml
@@ -8,6 +8,6 @@ Mrot:
     build: MROT_1.0
     checksums:
         gdna: 94837ed0a2ec223505a5a5d23f391f7afe39ed73
-        gff3: 7d60b8b6e8acbc971d2c4d064bcbdb143f5eaf1a
+        gff3: fdcdac42a01f89febb0b59ff69656a131f64445e
         prot: 0d4275649a842448dadd8525da8bf8636eed4fa6
     description: MROT_1.0 from the University of Maryland

--- a/genhub/genomes/Oluc.yml
+++ b/genhub/genomes/Oluc.yml
@@ -7,6 +7,6 @@ Oluc:
     build: ASM9206v1
     checksums:
         gdna: 5d1b5aaf55e4bf15d72d701935877641f25afa42
-        gff3: 7697572d693eb6944323a19dacdd3a75250761bc
+        gff3: 071ac022d42f3a742e5c4aa908690b9b5592617f
         prot: 3726074a747deb6732c477f86c36d50ab806418f
     description: ASM9206v1 from JGI

--- a/genhub/genomes/Osat.yml
+++ b/genhub/genomes/Osat.yml
@@ -15,7 +15,7 @@ Osat:
         - NC_001751.1
         - NC_001320.1
     checksums:
-        gdna: b2fc7c1edae88e45378efb036ccaf65974d843b2
-        gff3: 8f047628719cedbed3e4b1819aaa02b5751f80b3
-        prot: 74ad98d573df60ee0c607377d1d40067b5c128fb
+        gdna: 677e03458cf5149d053c0e4bf4e42da6b7674701
+        gff3: baf948e97a8d07f60e7a18c5643e399da8403e63
+        prot: 82f4cc25a3ccababfeee0ddae4a4d0fbe34f5423
     description: Nipponbare reference from the IRGSP

--- a/genhub/genomes/Pbar.yml
+++ b/genhub/genomes/Pbar.yml
@@ -8,6 +8,6 @@ Pbar:
     build: Pbar_UMD_V03
     checksums:
         gdna: 5deee484ae7e219b91bec975d9206378c8417f49
-        gff3: f0523af8e2b578c1e789d1aed460a670d3bedb16
+        gff3: 3f266f4e7b5bd738d4a27f2f6ed15dacc10b7c36
         prot: 0c1084c83bfa693c5075ebcf0cf7d5bafe7fe7c6
     description: Pbar_UMD_V03 from the Ant Genomics Consortium

--- a/genhub/genomes/Pcan.yml
+++ b/genhub/genomes/Pcan.yml
@@ -8,6 +8,6 @@ Pcan:
     build: ASM131383v1
     checksums:
         gdna: f9ee6e692ddaccd7f62842c26a3fe1e4946254a6
-        gff3: a86b053c61d7387273429ac0c9d006a605b07e80
+        gff3: 65acc87be77f3219f7efc164acb28f04ea210df9
         prot: 73902f0398b0a063508541ecb5973714fd8934e3
     description: ASM131383v1 from the CRG

--- a/genhub/genomes/Pdom.yml
+++ b/genhub/genomes/Pdom.yml
@@ -8,6 +8,6 @@ Pdom:
     build: Pdom_r1.2
     checksums:
         gdna: 4b2d1859b64bf1c89f480e2ce50c7f8d6e4d83a6
-        gff3: 36258c2afa2211b4d9591c7b9ba16197afe41001
+        gff3: 1bd437794bfdb0a9cda1992d3a559ec2282573ab
         prot: f5e9c384bc182e3e50029ad3fdf2a8f4afbdfd83
     description: Pdom r1.2 from the Toth lab

--- a/genhub/genomes/Pfal.yml
+++ b/genhub/genomes/Pfal.yml
@@ -12,6 +12,6 @@ Pfal:
         - NC_002375.1
     checksums:
         gdna: 51c207b62a7b678fcf2bcde7f665dfec1d77f146
-        gff3: ff708cd56c5e6596bf71acf781a26ce4e5d1d770
+        gff3: 0abddf9d1e81976e593df8d2687afc972f5f3a07
         prot: 099af2fd4d703129f26ae3474a2f08ab29298fd6
     description: ASM276v1 from the P. falciparum Genome Sequencing Consortium

--- a/genhub/genomes/Scer.yml
+++ b/genhub/genomes/Scer.yml
@@ -18,6 +18,6 @@ Scer:
         - NC_001224.1
     checksums:
         gdna: b422facd27488fda09236e608b2a8d14d2b9bec0
-        gff3: 746ff4b4c3eafc5e3391cf5a2b505107d7a72faa
+        gff3: 5a67ec133df34bf2b25a624335afc30f81d7fc03
         prot: 99b1bc8f116e5a19525d61e0a5ef240b266271d4
     description: R64 from SGD

--- a/genhub/genomes/Sinv.yml
+++ b/genhub/genomes/Sinv.yml
@@ -13,6 +13,6 @@ Sinv:
         - NC_014672.1
     checksums:
         gdna: 85f90adfa3663d5aee9b698b0dc1dac5132e3832
-        gff3: ccbe6bb367bbae90724a3362ec138ee6ebc6934d
+        gff3: e3c7da343eae86d2ab601003caeb62d376015dba
         prot: 34f140008239cc319225e0e4c6a00d345f2b50be
     description: Si_gnG from the University of Lausanne

--- a/genhub/genomes/Tcac.yml
+++ b/genhub/genomes/Tcac.yml
@@ -13,6 +13,6 @@ Tcac:
         - GeneID:18609433
     checksums:
         gdna: 85c3785160482dbd5a4ba630b0f6d005d248a484
-        gff3: 7837d324a643677e74827f36d18b33ea800cf6b1
+        gff3: a21e592334f50af780654e3ddfab01d9d7dfa042
         prot: 634c53b575351fe809fb7e925f26aa95204d5800
     description: Build 20110822 from the Cacao genome consortium

--- a/genhub/genomes/Turt.yml
+++ b/genhub/genomes/Turt.yml
@@ -11,6 +11,6 @@ Turt:
         - NC_010526.1
     checksums:
         gdna: 3d75b35d2eed4fdd73a12a4975499ae7e92c3ab3
-        gff3: 297525fe1d5c28732bf3cde281ca61e943059220
+        gff3: 8047ea56c1079ac359342e80d71517e17abdf10c
         prot: 65f108e91242395055c06da7649c0a4f670582a1
     description: ASM23943v1 from JGI

--- a/genhub/genomes/Vcar.yml
+++ b/genhub/genomes/Vcar.yml
@@ -7,6 +7,6 @@ Vcar:
     build: v1.0
     checksums:
         gdna: 1eb1efef4260647cb76da2874e3a20a21d339459
-        gff3: 4551f29926cc67d7438c7b804af1e97c15198d4c
+        gff3: a46e2914164e8e04853f21ee8e6c4137f514498e
         prot: 3f426492b05a6fabc9c6faf60d4ad525ea0bd383
     description: v1.0 from JGI

--- a/genhub/genomes/Xtro.yml
+++ b/genhub/genomes/Xtro.yml
@@ -12,6 +12,6 @@ Xtro:
     build: Xtropicalis_v7
     checksums:
         gdna: 4d12fdfc16987669d9ea8c76561b358449dc7f85
-        gff3: dec368cc20869449aaf5fef4d80f7370712b941e
-        prot: a319182a059c90d6bd1453c86762decd4d7a8cfc
+        gff3: fbcbb0e4aa911014ff70b6a8d34c86fe51bdc734
+        prot: da57293d96402a43cf4cebf8d25d9360c258bca9
     description: Xtropicalis_v7 from JGI


### PR DESCRIPTION
Updated checksums for many NCBI annotations to compensate for:
- changes in `##species` pragmas
- transcript evidence descriptions and other metadata
- feature types for annotated mobile elements, antisense transcripts, origins of replication, and various other features
- an update to the _C. elegans_ annotation (< 1% gene models affected)
- an update to the _D. rerio_ annotation (≈ 3% CDS exons, ≈ 10% all exons affected)
- an update to the _M. musculus_ annotation (1% CDS exons, 5% of all exons affected)

Not having used GenHub very frequently for the last two months has made me question whether checksums are a good, sustainable idea long-term for flagging changes in the data. Even inconsequential changes (GFF3 metadata or Fasta defline descriptions) affect the checksum even if the primary data remains unchanged. There's also the very unfortunate fact that NCBI RefSeq does not issue new accession numbers for new annotation builds associated with a RefSeq assembly.

For now I'll continue to rely on checksums, but will investigate the use of `gt speck` for monitoring and validating the annotations. See #80.
